### PR TITLE
Add support for About methods

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -125,7 +125,17 @@ module.exports = function(access_token) {
       }
     }
   }
-  
+
+  resources.about = function(fileId) {
+
+    return {
+      get: function(params, cb) {
+        var p = extract_params(undefined, params, cb);
+        return make_request(p).get(base_uri + '/about', p.cb);
+      },
+    }
+  }
+
 	/*
 		Changes
 		For Changes Resource details, see below about Resource representations.


### PR DESCRIPTION
This adds support for the [About get method](https://developers.google.com/drive/v2/reference/about). 

